### PR TITLE
feat: add sensor alert schema to webhook schema

### DIFF
--- a/worker/test/webhook_negative.spec.ts
+++ b/worker/test/webhook_negative.spec.ts
@@ -46,6 +46,10 @@ describe('The webhook', () => {
 			body: {
 				sharedSecret: 'invalid secret',
 				alertTypeId: 'client_connectivity',
+				alertData: {
+					clientName: 'blah',
+					connected: 'true',
+				},
 			},
 		});
 		expect(response.status).toBe(403);


### PR DESCRIPTION
This patch refactors the webhook alert schema to use Zod's discriminated unions support in order to easily handle parsing the different types.