### PR TITLE
chore: add specific labels and limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "ignorePaths": ["**/.dagger/**"]
+    "ignorePaths": ["**/.dagger/**"],
+    "labels": ["renovate", "dependencies"],
+    "prHourlyLimit": 10
 }


### PR DESCRIPTION
This patch adds the `dependencies` and `renovate` labels to every PR opened by Renovate. Additionally, we increase the hourly limit for PR creation to allow updates to be added more frequently.