### PR TITLE
chore: add yarn@4 to package.json

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -29,7 +29,8 @@ func (m *Powerbuddy) BuildEnv(
 		From(nodeBase).
 		WithDirectory("/src", source).
 		WithWorkdir("/src/worker").
-		WithExec([]string{"yarn"}), nil
+		WithExec([]string{"corepack", "install"}).
+		WithExec([]string{"corepack", "yarn"}), nil
 }
 
 // Runs tests
@@ -43,6 +44,6 @@ func (m *Powerbuddy) Test(
 		return "", err
 	}
 	return buildEnv.
-		WithExec([]string{"yarn", "test", "--run"}).
+		WithExec([]string{"corepack", "yarn", "test", "--run"}).
 		Stdout(ctx)
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
 "aqua:dagger/dagger" = "latest"
 node = "latest"
-yarn = "latest"

--- a/worker/package.json
+++ b/worker/package.json
@@ -30,5 +30,6 @@
 		"vitest@3.2.4": {
 			"unplugged": true
 		}
-	}
+	},
+	"packageManager": "yarn@4.9.2+sha512.1fc009bc09d13cfd0e19efa44cbfc2b9cf6ca61482725eb35bbc5e257e093ebf4130db6dfe15d604ff4b79efd8e1e8e99b25fa7d0a6197c9f9826358d4d65c3c"
 }


### PR DESCRIPTION
Seems like Renovate struggles to run the correct version of Yarn without this configuration.